### PR TITLE
Nhut nguyen/final version

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -36,3 +36,23 @@
     transform: rotate(360deg);
   }
 }
+
+.wrapper {
+  text-align: center;
+  margin-top: 27px;
+}
+
+.PAutoCompleteWrapper {
+  display:inline-block;
+  width: 365px;
+}
+
+@media (max-width: 767px) {
+  .wrapper {
+    margin-top: 45px;
+  }
+  .PAutoCompleteWrapper {
+    display:inline-block;
+    width: 90%;
+  }
+}

--- a/src/App.js
+++ b/src/App.js
@@ -45,12 +45,14 @@ class App extends React.Component {
   }
   render() {
     return (
-      <PAutoComplete
-        value={this.state.keyword}
-        suggestions={this.state.results}
-        onChange={(val) => this.search(val)}
-        onSelect={(item) => this.updateKeyword(item) && this.updateResult([])}
-      />
+      <div className="wrapper">
+        <PAutoComplete
+            value={this.state.keyword}
+            suggestions={this.state.results}
+            onChange={(val) => this.search(val)}
+            onSelect={(item) => this.updateKeyword(item) && this.updateResult([])}
+        />
+      </div>
     )
   }
 }

--- a/src/components/elements/PInput.js
+++ b/src/components/elements/PInput.js
@@ -6,6 +6,7 @@ export default (props) => {
     <input
       value={props.value}
       onChange={(e) => props.onChange(getValue(e))}
-    ></input>
+      type={props.type}
+    />
   )
 }

--- a/src/components/elements/PListItem.js
+++ b/src/components/elements/PListItem.js
@@ -1,6 +1,6 @@
 import React from 'react'
 export default (props) => {
   return (
-    <p onClick={(e) => props.onPress && props.onPress(e)}>{props.children}</p>
+    <div onClick={(e) => props.onPress && props.onPress(e)}>{props.children}</div>
   )
 }

--- a/src/components/widgets/PAutoComplete.css
+++ b/src/components/widgets/PAutoComplete.css
@@ -1,0 +1,56 @@
+.PAutoCompleteWrapper {
+    display:inline-block;
+}
+
+.result {
+    display: inline-block;
+    width: 100%;
+    border: 1px solid #E0E0E0;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+    margin-top: 8px;
+    box-sizing: border-box;
+}
+
+.result div {
+    border-bottom: 1px solid #E0E0E0;
+    padding: 15px 12px;
+    box-sizing: border-box;
+    text-align: left;
+    font-size: 16px;
+    color: #828282;
+}
+
+.result div:last-child {
+    border-bottom: unset;
+    padding: 15px 12px;
+}
+
+input {
+    width: 100%;
+    height: 40px;
+    border: 1px solid #E0E0E0;
+    border-radius: 2px;
+    padding-left: 15px;
+    padding-right: 15px;
+    box-sizing: border-box;
+    font-size: 16px;
+    font-weight: bold;
+}
+
+@media (max-width: 767px) {
+    .result {
+        width: 100%;
+        border: unset;
+        box-shadow: unset;
+        margin-top: 8px;
+    }
+    .result div {
+        border-bottom: unset;
+        padding: 15px 12px;
+    }
+}
+
+.keySearch {
+    font-weight: bold;
+    color: #282c34;
+}

--- a/src/components/widgets/PAutoComplete.js
+++ b/src/components/widgets/PAutoComplete.js
@@ -1,8 +1,10 @@
 import { PInput, PListItem, PList } from '../elements'
+import './PAutoComplete.css'
 import React from 'react'
+
 export default (props) => {
   return (
-    <div>
+    <div className='PAutoCompleteWrapper'>
       <PInput
         value={props.value}
         onChange={(val) => props.onChange && props.onChange(val)}

--- a/src/components/widgets/PAutoComplete.js
+++ b/src/components/widgets/PAutoComplete.js
@@ -2,6 +2,22 @@ import { PInput, PListItem, PList } from '../elements'
 import './PAutoComplete.css'
 import React from 'react'
 
+const formatItem = (search, item) => {
+    if(item.length>0) {
+        if(search.length>0) {
+            let substr1 = item.substring(0, search.length);
+            let substr2 = item.substring(search.length, item.length);
+            return(
+                <span>
+                    <span className='keySearch'>{substr1}</span>
+                    <span>{substr2}</span>
+                </span>
+            );
+        }
+    }
+    return item;
+}
+
 export default (props) => {
   return (
     <div className='PAutoCompleteWrapper'>
@@ -18,7 +34,7 @@ export default (props) => {
                 props.onSelect && props.onSelect(item)
               }}
             >
-              {item}
+              {formatItem(props.value, item)}
             </PListItem>
           ))}
         </PList>

--- a/src/fake-api/search.js
+++ b/src/fake-api/search.js
@@ -6,7 +6,6 @@ export default {
   search(key) {
     console.log(`Start calling Search API with "${key}" at: ${new Date().toLocaleTimeString()}`)
     return new Promise((resolve) => {
-      setTimeout(() => {
         console.log(
           `Complete calling Search API with "${key}" at: ${new Date().toLocaleTimeString()}`
         )
@@ -15,7 +14,6 @@ export default {
             item.toLocaleLowerCase().startsWith(key.toLocaleLowerCase())
           )
         )
-      }, parseInt(Math.random() * 5000))
     })
   },
 }


### PR DESCRIPTION
1. For UI on PC and mobile:
 + Added:
    - PAutoComplete.css: style common css for PAutoComplete component.
   - App.css: add new  css to responsive web app on PC on  mobile.
   - App.js: add new wrapper for App component to easy style css for it.
   - PAutoComplete.js: add 'formatItem' function to style behavior when display items match with key search.
 + Refactored:
    - PInput.js: add new 'type' prop for input because input can have many different types such as: 
    'text', 'button',...
    - PListItem.js: change 'p' tag to 'div' tag: correct with syntax of html and ez to css for item.
2. For the issue KI-01 and KI-02:
  +How to fix: remove setimeOut function in search.js 