### PR TITLE
viet_vo/final_version

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,6 @@
 .App {
-  text-align: center;
+  min-height: 100vh;
+  padding-top: 32px;
 }
 
 .App-logo {
@@ -34,5 +35,15 @@
   }
   to {
     transform: rotate(360deg);
+  }
+}
+
+.auto-complete-container {
+  width: 100%;
+}
+
+@media (min-width: 575.98px) {
+  .auto-complete-container {
+    width: 300px;
   }
 }

--- a/src/components/elements/PInput.js
+++ b/src/components/elements/PInput.js
@@ -3,7 +3,7 @@ import React from 'react'
 export default (props) => {
   const getValue = (e) => (e.target || e.currentTarget || {}).value
   return (
-    <input
+    <input className="p-input"
       value={props.value}
       onChange={(e) => props.onChange(getValue(e))}
     ></input>

--- a/src/components/elements/PList.js
+++ b/src/components/elements/PList.js
@@ -1,4 +1,4 @@
 import React from 'react'
 export default (props) => {
-  return <div className='result'>{props.children}</div>
+  return <div className='p-list'>{props.children}</div>
 }

--- a/src/components/elements/PListItem.js
+++ b/src/components/elements/PListItem.js
@@ -1,6 +1,6 @@
 import React from 'react'
 export default (props) => {
   return (
-    <p onClick={(e) => props.onPress && props.onPress(e)}>{props.children}</p>
+    <div className="p-list-item" onClick={(e) => props.onPress && props.onPress(e, props.dataCallback)}>{props.children}</div>
   )
 }

--- a/src/components/elements/elements.css
+++ b/src/components/elements/elements.css
@@ -1,0 +1,26 @@
+.p-input {
+  border: 1px solid #e1e1e1;
+  padding: 8px;
+  outline: none;
+  width: 100%;
+}
+
+.p-list {
+  margin-top: 8px;
+}
+
+.p-list .p-list-item {
+  padding: 8px;
+}
+
+@media (min-width: 575.98px) {
+  .p-list {
+    box-shadow: 0px 3px 8px 2px rgba(0, 0, 0, 0.2);
+    background-color: white;
+    border: 1px solid #e1e1e1;
+  }
+
+  .p-list .p-list-item:not(:last-child) {
+    border-bottom: 1px solid #e1e1e1;
+  }
+}

--- a/src/components/elements/index.js
+++ b/src/components/elements/index.js
@@ -1,6 +1,7 @@
 import Input from './PInput'
 import List from './PList'
 import ListItem from './PListItem'
+import './elements.css'
 export const PList = List
 export const PListItem = ListItem
 export const PInput = Input

--- a/src/components/widgets/PAutoComplete.js
+++ b/src/components/widgets/PAutoComplete.js
@@ -1,5 +1,42 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import { PInput, PListItem, PList } from '../elements'
-import React from 'react'
+import React, { useCallback } from 'react'
+
+const MemoizeItem = React.memo(({ data, handlePress, keyword }) => {
+  const highlightText = data.slice(0, keyword.length);
+  const nonHighlighText = data.slice(keyword.length)
+  return (
+    <PListItem
+      onPress={handlePress}
+      dataCallback={data}
+    >
+      <span className="font-weight-bold">{highlightText}</span>{nonHighlighText}
+    </PListItem>
+  )
+})
+
+const MemoizeList = React.memo(({keyword, onSelect, suggestions }) => {
+
+  const handlePress = useCallback((e, dataCallback) => {
+    onSelect && onSelect(e, dataCallback)
+  }, [])
+
+  return (
+    <PList>
+
+      {/* filter one more time in FE, in case the result from the previous AJAX still exist in the UI and the user typing too fast*/}
+      {/* so it will give better UX for the user as they see the list change accordingly immediately*/}
+      {/* when the AJAX return, it will update the latest search result */}
+      {/* maybe consider to use useMemo if the filter is too slow in future */}
+      {suggestions.filter((item) => {
+        return item.toLocaleLowerCase().startsWith(keyword.toLocaleLowerCase())
+      }).map((item) => (
+        <MemoizeItem key={item} keyword={keyword} handlePress={handlePress} data={item}></MemoizeItem>
+      ))}
+    </PList>
+  )
+})
+
 export default (props) => {
   return (
     <div>
@@ -8,18 +45,7 @@ export default (props) => {
         onChange={(val) => props.onChange && props.onChange(val)}
       ></PInput>
       {props.suggestions && props.suggestions.length > 0 ? (
-        <PList>
-          {props.suggestions.map((item) => (
-            <PListItem
-              key={item}
-              onPress={() => {
-                props.onSelect && props.onSelect(item)
-              }}
-            >
-              {item}
-            </PListItem>
-          ))}
-        </PList>
+        <MemoizeList keyword={props.value} suggestions={props.suggestions} onSelect={props.onSelect}></MemoizeList>
       ) : null}
     </div>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,18 @@
+*, ::after, ::before {
+  box-sizing: border-box;
+}
+
+html, input {
+  font-size: 18px;
+  color: rgba(0, 0, 0 ,0.87)
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
+  font-size: 18px;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -10,4 +20,28 @@ body {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
+}
+
+.m-auto {
+  margin: auto;
+}
+
+.w-100 {
+  width: 100%;
+}
+
+.d-block {
+  display: block;
+}
+
+.font-weight-bold {
+  font-weight: bold;
+}
+
+.container {
+  width: 100%;
+  padding-right: 15px;
+  padding-left: 15px;
+  margin-right: auto;
+  margin-left: auto;
 }

--- a/src/services/searchService.js
+++ b/src/services/searchService.js
@@ -1,0 +1,62 @@
+import FakeSearchAPI from '../fake-api/search'
+
+const CACHE_KEY = 'P_CACHED_SEARCH';
+export default (function() {
+
+  var cachedSearchStore = loadCache();
+
+  async function cachedSearch(keyword, cache = true) {
+    keyword = keyword.toLocaleLowerCase();
+    let cachedResult = loadCachedByKey(keyword);
+    if (cachedResult) {
+      return cachedResult;
+    } else {
+      for (let key in cachedSearchStore) {
+        if (key && keyword.startsWith(key)) {
+          let tempResult = loadCachedByKey(key);
+          tempResult = tempResult.filter(item => item.toLocaleLowerCase().startsWith(keyword.toLocaleLowerCase()))
+          if (tempResult.length > 0) return tempResult;
+        }
+      }
+    }
+
+    const result = await FakeSearchAPI.search(keyword);
+    if (cache) {
+      saveCache(keyword, result)
+    }
+
+    return result;
+  };
+
+  function loadCache() {
+    const cache = localStorage.getItem(CACHE_KEY);
+    if (cache) {
+      try {
+        const obj = JSON.parse(cache);
+        return obj;
+      } catch {
+        return {};
+      }
+    }
+    return {}
+  }
+
+  function loadCachedByKey(key) {
+    return cachedSearchStore[key];
+  }
+
+  function saveCache(key, data) {
+    cachedSearchStore[key] = data;
+    localStorage.setItem(CACHE_KEY, JSON.stringify(cachedSearchStore));
+  }
+
+  function clearCache() {
+    cachedSearchStore = {};
+    localStorage.removeItem(CACHE_KEY)
+  }
+
+  return {
+    cachedSearch, loadCache, saveCache, loadCachedByKey, clearCache
+  }
+
+})();

--- a/src/util/debounce.js
+++ b/src/util/debounce.js
@@ -1,0 +1,13 @@
+export default function (func, wait) {
+  let timeout;
+  return function () {
+    const context = this;
+    const args = arguments;
+    const later = function () {
+      timeout = null;
+      func.apply(context, args);
+    };
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+  };
+};


### PR DESCRIPTION
Added:
 - CachedSearchService: to cached search result in FE because the search API too slow
 - MemoizeItem and MemoizeList component: that is the wrapper of PlistItem and Plist. The list rendering may be expensive, so it's better to use React.memo. Just keep PListItem and Plist that way for better reusable. The inline callback inside PListItem is not too expensive, just keep it so the code looks simple, and we also have MemoizeItem to prevent wasted render.

Refactored:
 - Refactor PAutocomplete to use MemoizeItem and MemoizeList.
 - Refactor App Component. There's an inline callback. It causes wasted re-render on the list even if we use React.memo for MemoizeList

Fixed:
 - `KI-01`: That's because the AJAX result is not return in order. So after the AJAX return, only update the list if (keyword===this.state.keyword)
 - `KI-02`:
		- Cached on FE. Note: the cached I implemented based on assumption that the FakeAPI only compare string by `startWith` function and the DB doesn't change much. It's better to add expired time for the cache but I didn't do it yet.
			Eg: cachedSearch('m') -> return 'Mabel Golden' - > cached {m: 'Mabel Golden'}
			       cachedSearch('ma') -> get from cached {m: 'Mabel Golden'} -> Filter one more time in search service cached
			       cachedSearch('mb') -> call AJAX because the list from {m: 'Mabel Golden'} is empty after filtered with 'mb'
		- Debounce search on typing (300ms). So if the user type too fast the search can't be triggered.
		- Filter the list one more time on the view when typing(at that time the search have not trigger yet), so if the previous search result still exist, that give the better UX as the user will see the list change immediately